### PR TITLE
#!/usr/bin/env node

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict'
 const Publish = require('./index')
 const meow = require('meow')


### PR DESCRIPTION
So OS X and maybe others can use the right version of Node.
